### PR TITLE
fix LightCondensed layerContents.plist

### DIFF
--- a/MutatorSansLightCondensed.ufo/layercontents.plist
+++ b/MutatorSansLightCondensed.ufo/layercontents.plist
@@ -26,17 +26,5 @@
       <string>support.S.middle</string>
       <string>glyphs.support.S_.middle</string>
     </array>
-    <array>
-      <string>skateboard_support_width_122.24_weight_496.51</string>
-      <string>glyphs.skateboard_support_width_122.24_weight_496.51</string>
-    </array>
-    <array>
-      <string>skateboard_support_width_475.08_weight_417.40</string>
-      <string>glyphs.skateboard_support_width_475.08_weight_417.40</string>
-    </array>
-    <array>
-      <string>skateboard_support_width_1000.00_weight_815.18</string>
-      <string>glyphs.skateboard_support_width_1000.00_weight_815.18</string>
-    </array>
   </array>
 </plist>


### PR DESCRIPTION
Was getting error trying to open this UFO in RF “A glyphset does not exist at glyphs.skateboard_support_width_122.24_weight_496.51” 

Deleting these from layerContents.plist seems to fix the issue.